### PR TITLE
138 codeowner and maintainer for the governance repository

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,13 @@
+# This file provides an overview of code owners in this repository.
+
+# Each line is a file pattern followed by one or more owners.
+# The last matching pattern has the most precedence.
+# For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
+
+# These are the default owners for the whole content of this repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
+# For this repository the owners are the Chair and the Co-chairs of the Technical Steering Committee (TSC)
+* @hdamker @eric-murray @bigludo7
+
+# Owners of the CODEOWNER and Maintainer.md files are the admins of CAMARA (to allow them to keep the teams within the CAMARA organization in sync in case of changes)
+/CODEOWNERS @camaraproject/admins
+/MAINTAINERS.MD @camaraproject/admins

--- a/MAINTAINERS.MD
+++ b/MAINTAINERS.MD
@@ -1,0 +1,5 @@
+Maintainer for the content within the Governance repository are the participants of the Technical Steering Committee (TSC), as defined within the [ProjectCharter](https://github.com/camaraproject/Governance/blob/main/ProjectCharter.md) of CAMARA.
+
+The current list of TSC participants can be found at https://wiki.camaraproject.org/x/KAAG or https://camaraproject.org/steering-committee/
+
+Within issues and pull request reviews the team can be addressed via @camaraproject/tsc-participants


### PR DESCRIPTION
#### What type of PR is this?

<!-- Use one of the following kinds (delete the others) -->

* project management


#### What this PR does / why we need it:

Adding CODEOWNERS and MAINTAINERS.MD file in the repository as discussed in #138 and TSC on June 6th.


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #138

#### Special notes for reviewers:

The MAINTAINERS.MD file does not list the TSC participants, but points to the existing documentation of them.

