### PR TITLE
Adding description for "support of an API" within API-onboarding.md

### DIFF
--- a/documentation/API-onboarding.md
+++ b/documentation/API-onboarding.md
@@ -39,7 +39,7 @@ The whole procedure (steps 1-4) should be done within 2 regular meetings of the 
 
 In parallel, the API proposal is formally registered in CAMARA by adding it to the [CAMARA API overview list](https://github.com/camaraproject/APIBacklog/blob/main/documentation/APIbacklog.md) The WG chair creates a new line in the table and fills in API family name, API family owner, API family proposal registration date, the link to the application template and the supporters for it.
 
-NOTE: Supporting an API proposal means that the supporting company must provide at least 1 (one) Maintainer at the time of the subgroup creation. This applies not only to the new API proposals but also for those Scope Enhancements in which the creation of a new "child" repository is required.
+NOTE: Supporting an API proposal means that the supporting company must provide at least 1 (one) Maintainer at the time of the Sub Project creation. This applies not only to new API proposals but also for those Scope Enhancements of a Sub Project in which the creation of a new repository is required.
 
 ## TSC decision on API proposal
 

--- a/documentation/API-onboarding.md
+++ b/documentation/API-onboarding.md
@@ -39,6 +39,8 @@ The whole procedure (steps 1-4) should be done within 2 regular meetings of the 
 
 In parallel, the API proposal is formally registered in CAMARA by adding it to the [CAMARA API overview list](https://github.com/camaraproject/APIBacklog/blob/main/documentation/APIbacklog.md) The WG chair creates a new line in the table and fills in API family name, API family owner, API family proposal registration date, the link to the application template and the supporters for it.
 
+NOTE: Supporting an API proposal means that the supporting company must provide at least 1 (one) Maintainer at the time of the subgroup creation. This applies not only to the new API proposals but also for those Scope Enhancements in which the creation of a new "child" repository is required.
+
 ## TSC decision on API proposal
 
 Upon receiving the API proposal and notification from the WG chair, the TSC studies the proposal and votes it at the TSC meeting.


### PR DESCRIPTION
#### What type of PR is this?

* documentation


#### What this PR does / why we need it:
Within [last TSC meeting](https://wiki.camaraproject.org/display/CAM/2024-06-06+TSC+Minutes) it have been required to provide the obligations of a supporting company in an API proposal



#### Which issue(s) this PR fixes:

Fixes #143 
