### PR TITLE
Update Email_Settings.md - added config of "codewoners" list

### DIFF
--- a/documentation/Email_Settings.md
+++ b/documentation/Email_Settings.md
@@ -27,6 +27,13 @@ For "**board**" + "**tsc-private**":
 * Message Policies:
   * Allow Parent Members to Post: no
 
+For "**codeowners**":
+* Group Type and Moderation:
+  * Restricted Membership: Yes
+  * New Members Moderation: No
+* Message Policies:
+  * Allow Parent Members to Post: no
+
 For "**all**":
 * Group Type and Moderation:
   * Message Moderation: All Messages are moderated.


### PR DESCRIPTION
#### What type of PR is this?

* documentation

#### What this PR does / why we need it:

codeowner@lists.camaraproject.org is another list with a specfic configuration.
Membership is restricted, members are all codeowner in at least one repository of CAMARA.
Visibility is public, and the mailing list can be addressed by all CAMARA participants.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes # na

