### PR TITLE
Increase TSC Sub Project representatives from 10 to 12 (fixes #206)

### DIFF
--- a/ProjectCharter.md
+++ b/ProjectCharter.md
@@ -142,12 +142,12 @@ is created.
 **Technical Steering Committee (TSC)**
 
 The Technical Steering Committee is composed of:
--	10 representatives of Sub Projects as selected by the Maintainers of Sub Projects and Working Groups (“Sub Project representatives”); 
+-	12 representatives of Sub Projects as selected by the Maintainers of Sub Projects and Working Groups ("Sub Project representatives"); 
 -	3 representatives of the End-User Council as selected by the End-User Council (“EUC representatives”); 
 -	1 non-voting representative of the GSMA and
 -	1 non-voting representative of the TMForum
 
-Any Maintainer may nominate themselves or another Maintainer of any Sub Project or Working Group for consideration as a Sub Project representative. The Maintainers will vote using ranked choice voting (or another method approved by the TSC) and those 10 nominees receiving the highest number of votes will be elected to the TSC as Sub Project representatives.
+Any Maintainer may nominate themselves or another Maintainer of any Sub Project or Working Group for consideration as a Sub Project representative. The Maintainers will vote using ranked choice voting (or another method approved by the TSC) and those 12 nominees receiving the highest number of votes will be elected to the TSC as Sub Project representatives.
 
 Any participant of the EUC may recommend any participant of the EUC for consideration as a EUC representative. EUC participants will vote using ranked choice voting (or another method approved by the TSC) and those 3 nominees receiving the highest number of votes will be elected as EUC representatives.
 


### PR DESCRIPTION
#### What type of PR is this?

* project management

#### What this PR does / why we need it:

Increases TSC Sub Project representatives from 10 to 12 seats to accommodate qualified nominees and support project growth.

#### Which issue(s) this PR fixes:

Fixes #206

#### Special notes for reviewers:

This PR remains in draft status pending TSC vote approval per Charter amendment process.