### PR TITLE
Fix broken links and typos in ProjectStructureAndRoles

### DIFF
--- a/ProjectStructureAndRoles.md
+++ b/ProjectStructureAndRoles.md
@@ -38,7 +38,7 @@ Each API Repository must have a README.md file (with a description of the API sc
 
 Each API Repository should have subdirectories /documentation/API_documentation, /documentation/SupportingDocuments, /code/API_definitions, and /code/Test_definitions. 
   
-API Repositories can have in addition Provider Implementation (PI) Repositories on their side. Provider Implementation Repositories only must have a CODEOWNERS file, a license file, a GOVERNANCE.MD file (pointing to the Governance repository) and a subdirectory /code/API_code with API code of the transformation function Northbound --> Southbound. Only Codeowners should have write permissions to a Provider Implementation (PI) Repository. Provider Implementation Repositories have the same name as the API Repository but with suffix `_PI` or `_PIn`.
+API Repositories can have in addition Provider Implementation (PI) Repositories on their side. Provider Implementation Repositories only must have a CODEOWNERS file, a license file, a GOVERNANCE.MD file (pointing to the Governance repository) and a subdirectory /code/API_code with API code of the transformation function Northbound --> Southbound. Only Codeowners should have write permissions to a Provider Implementation (PI) Repository. Provider Implementation Repositories have the same name as the API Repository but with suffix `_PI` or `_PIn` (with n as Integer).
 
 **Sandbox API Repositories**
 


### PR DESCRIPTION

#### What type of PR is this?

* correction
* documentation

#### What this PR does / why we need it:

- Fix broken links to 'API-Onboarding-and-Lifecycle.md' by pointing to the 'documentation/' directory.
- Convert absolute links to relative links for 'CONTRIBUTING.md' and images to ensure portability.
- Standardize file references (e.g., 'README.md', 'MAINTAINERS.MD') to match actual filenames and casing.
- Correct typos: 'ProjectCharter' to 'Project Charter', 'participantship' to 'participation'.
- Remove text artifacts (e.g., 'suffix _-PI§x§_').

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #208 

#### Special notes for reviewers:

This PR is about obvious fixes of links, file names, and typos. Please don't use it to propose substantial changes to the content, for that please open a separate issue.


