### PR TITLE
Remove Slack references from Governance documentation

### DIFF
--- a/ProjectStructureAndRoles.md
+++ b/ProjectStructureAndRoles.md
@@ -48,7 +48,7 @@ A Sandbox API Repository can be created independent of a CAMARA Sub Project (Ind
 
 * If a Sandbox API Repository belongs to a Sub Project it links within the README.md to the Sub Project wiki home page. Mailing list, meetings will be for these Sandbox API Repositories organized in context of the Sub Project. The Sub Project may already nominate or approve Maintainers for the Sandbox API Repository, which are with that also Maintainers of the Sub Project.
 
-* An Independent Sandbox API Repository which is not part of an existing Sub Project will get a page in a separate section of the [CAMARA wiki](https://lf-camaraproject.atlassian.net/), a preliminary mailing list, a Slack channel, and (on request) a Zoom meeting to be able to communicate with the community and attract contributors. The MAINTAINERS.MD file of an Independent Sub Project may already list contributors who are committed to the support the API Repository as Maintainers. But they are not yet Maintainers of a Sub Project in the sense of the Project Charter.
+* An Independent Sandbox API Repository which is not part of an existing Sub Project will get a page in a separate section of the [CAMARA wiki](https://lf-camaraproject.atlassian.net/), a preliminary mailing list and (on request) a Zoom meeting to be able to communicate with the community and attract contributors. The MAINTAINERS.MD file of an Independent Sub Project may already list contributors who are committed to the support the API Repository as Maintainers. But they are not yet Maintainers of a Sub Project in the sense of the Project Charter.
 
 A Sandbox API Repository must have at least one Codeowner. If the Sandbox API Repository has two or more Codeowners the activation of branch protection rules is recommended.
 

--- a/documentation/API-Onboarding-and-Lifecycle.md
+++ b/documentation/API-Onboarding-and-Lifecycle.md
@@ -164,7 +164,7 @@ The Sandbox stage is the entry point for all new APIs. It is designed for experi
 - Open for contributions from any participant in the CAMARA Project.
 - No guarantees of stability or long-term support.
 - Can be initially independent, but should aim to either get accepted by an existing CAMARA Sub Project or to build up the necessary prerequisites to be able to apply for the creation of a new CAMARA Sub Project during Incubation.
-- A Sandbox API Repository which is not part of an existing Sub Project will get a Wiki page (in the Sandbox section), a preliminary mailing list, a Slack channel, and (on request) a Zoom meeting for their communication.
+- A Sandbox API Repository which is not part of an existing Sub Project will get a Wiki page (in the Sandbox section), a preliminary mailing list and (on request) a Zoom meeting for their communication.
 
 **Requirements:**
 - The scope of the proposed API and initial use cases are described and fit in general into the scope of CAMARA.
@@ -185,7 +185,7 @@ APIs in the Incubating stage have shown early promise with initial adoption and 
 
 **Characteristics:**
 - API(s) specified in an Incubating API repository warranty stability and long-term support.
-- An Incubating API repository is part of a CAMARA Sub Project with a sub project Wiki Page, mailing list, Slack channel and Zoom meeting for communication.
+- An Incubating API repository is part of a CAMARA Sub Project with a sub project Wiki Page, mailing list and Zoom meeting for communication.
 - **Can release Initial and Stable API versions.**
 
 **Requirements:**


### PR DESCRIPTION
#### What type of PR is this?

* documentation

#### What this PR does / why we need it:

Removes Slack channel references from ProjectStructureAndRoles.md and API-Onboarding-and-Lifecycle.md. CAMARA is migrating from Slack to Zulip and a dedicated messaging channel per repository is no longer part of the standard infrastructure.

#### Which issue(s) this PR fixes:

Fixes #212

#### Special notes for reviewers:

Historical meeting minutes (TSC-2023-10-05, TSC-2023-09-07) still reference Slack but are kept unchanged as they document past decisions.

#### Additional documentation 

None.